### PR TITLE
adapting to integers and other novelties in Python3

### DIFF
--- a/AuxilaryFunctions.py
+++ b/AuxilaryFunctions.py
@@ -15,7 +15,7 @@ from builtins import str
 from builtins import range
 from past.utils import old_div
 import numpy as np
-
+import os
 
 def make_sure_path_exists(path):
     import os
@@ -68,7 +68,7 @@ def GetDataFolder():
         
     import os
     
-    if os.getcwdu()[0]=='C':
+    if os.getcwd()[0]=='C':
         DataFolder='G:/BackupFolder/'
     else:
         DataFolder='Data/'
@@ -148,11 +148,13 @@ def GetData(data_name):
         data=np.asarray(data,dtype='float')  
         data=data[:,:200,:200] #take only a small patch
         data=data-np.min(data, axis=0)# takes care of negative values (ands strong positive values) in each pixel
-    elif data_name=='BaylorAxonsQuiet':           
-        temp=h5py.File(DataFolder + 'BaylorV1Axons/quietBlock.mat')
-        data=temp["quietBlock"]
-        data=np.asarray(data,dtype='float')  
-        data=data[:,150:350,150:350] #take only a small patch
+    elif data_name=='BaylorAxonsQuiet':   
+    
+        with h5py.File(os.path.join(DataFolder,u'BaylorV1Axons/quietBlock.mat')) as temp:
+
+            data=temp["quietBlock"]
+            data=np.asarray(data,dtype='float')  
+            data=data[:,150:350,150:350] #take only a small patch
 #        ds=3  #downscale time by this factor
 #        data=data[:int(len(data) / ds) * ds].reshape((-1, ds) + data.shape[1:]).mean(1)
         data=data-np.min(data, axis=0)# takes care of negative values (ands strong positive values) in each pixel

--- a/BlockLocalNMF_AuxilaryFunctions.py
+++ b/BlockLocalNMF_AuxilaryFunctions.py
@@ -443,7 +443,7 @@ def DownScale(data,mb,ds):
                 len(data0), old_div(dims[1], ds[0]), ds[0], old_div(dims[2], ds[1]), ds[1], old_div(dims[3], ds[2]), ds[2])\
                 .mean(2).mean(3).mean(4)
         else:
-            data0 = data0[:,:int(old_div(dims[1],ds[0])) *ds[0],:int(old_div(dims[2],ds[1])) *ds[1]].reshape(len(data0), old_div(dims[1], ds[0]), ds[0], old_div(dims[2], ds[1]), ds[1]).mean(2).mean(3)
+            data0 = data0[:,:int(old_div(dims[1],ds[0]) * ds[0]),:int(old_div(dims[2],ds[1]) *ds[1])].reshape(len(data0), int(old_div(dims[1], ds[0])), int(ds[0]), int(old_div(dims[2], ds[1])), int(ds[1])).mean(2).mean(3)
         # for i,d in enumerate(dims[1:]):
         #     data0 = data0.reshape(data0.shape[:1+i] + (d / ds, ds, -1)).mean(2+i)
 


### PR DESCRIPTION
Hey Daniel, 

Python 3 does not seem to accept anymore non integer indexes. So, I tried to fix some of the issues myself, but on my machine I bumped into an error that you should look at (see below). Let me know when you are done and I will continue.  For the time being check at my changes in this pull request. 

Cheers

Traceback (most recent call last):

  File "<ipython-input-25-52bee2bffc23>", line 20, in <module>
    Connected=params.Connected,SmoothBkg=params.SmoothBackground,FixSupport=params.FixSupport,bkg_per=params.bkg_per,iters0=params.iters0,iters=params.iters,mbs=params.mbs, ds=params.ds)

  File "/mnt/xfs1/home/agiovann/SOFTWARE/SourceExtraction/BlockLocalNMF.py", line 247, in LocalNMF
    S=LargestConnectedComponent(S,dims0,adaptBias)

  File "/mnt/xfs1/home/agiovann/SOFTWARE/SourceExtraction/BlockLocalNMF_AuxilaryFunctions.py", line 475, in LargestConnectedComponent
    structure=np.ones(tuple(3*np.ones((np.ndim(shapes)-1,1))))

  File "/mnt/xfs1/home/agiovann/anaconda3/lib/python3.5/site-packages/numpy/core/numeric.py", line 192, in ones
    a = empty(shape, dtype, order)

TypeError: only integer scalar arrays can be converted to a scalar index
